### PR TITLE
Change west coast alias

### DIFF
--- a/network_resources.tf
+++ b/network_resources.tf
@@ -2,7 +2,7 @@ terraform {
 provider "aws" {
   source  = "hashicorp/aws"
   region  = "us-west-2"
-  alias   = "us-west-2"
+  alias   = "us-west"
  }
 provider "aws" {
   source  = "hashicorp/aws"


### PR DESCRIPTION
Updated alias for one of the AWS providers for the us-west-2 region.