### PR TITLE
Fix the incorrect providers syntax

### DIFF
--- a/network_resources.tf
+++ b/network_resources.tf
@@ -24,6 +24,6 @@ module "vpc" {
   cidr   = "10.200.0.0/16"
 
   providers = {
-    name = "us-west" 
+    name = us-west 
    }
 }


### PR DESCRIPTION
Put the incorrect syntax under the **providers** section for the **VPC** module.  Fixed the issue with this branch.