### PR TITLE
Create public EC2 instances and grab dynamic AMI value

### DIFF
--- a/data_sources.tf
+++ b/data_sources.tf
@@ -1,4 +1,4 @@
-# Gather available azs for us-east-1 and us-west-2
+# Gather available azs for both regions
 data "aws_availability_zones" "region_1" {
 
   state    = "available"
@@ -9,5 +9,34 @@ data "aws_availability_zones" "region_2" {
 
   state    = "available"
   provider = aws.region_2
+
+}
+# Gather most recent AMI for amazon linux image in each region
+data "aws_ami" "amazon_linux_region_1" {
+
+  most_recent = true
+  owners = ["amazon"]
+  provider = aws.region_1
+  # Example of using filter, will return amazon linux image with arm64 architecture
+  # Can add more filters by repeating the filter option, name should reference the key you want to filter against
+  filter {
+    name = "architecture"
+    values = [
+      "x86_64"
+    ]
+  }
+
+}
+data "aws_ami" "amazon_linux_region_2" {
+
+  most_recent = true
+  owners = ["amazon"]
+  provider = aws.region_2
+  filter {
+    name = "architecture"
+    values = [
+      "x86_64"
+    ]
+  }
 
 }

--- a/ec2_instance_creation.tf
+++ b/ec2_instance_creation.tf
@@ -2,8 +2,8 @@
 resource "aws_instance" "private_ec2_region_1" {
 
   count                  = length(var.vpc_region1_private_subnets)
-  ami                    = var.private_ec2_ami_region_1
-  instance_type          = var.private_ec2_type
+  ami                    = data.aws_ami.amazon_linux_region_1.id
+  instance_type          = var.ec2_type
   availability_zone      = element(data.aws_availability_zones.region_1.names, count.index)
   subnet_id              = element(resource.aws_subnet.region_1_private_subnets.*.id, count.index)
   vpc_security_group_ids = [resource.aws_security_group.private_sg_region_1.id]
@@ -17,14 +17,44 @@ resource "aws_instance" "private_ec2_region_1" {
 resource "aws_instance" "private_ec2_region_2" {
 
   count                  = length(var.vpc_region2_private_subnets)
-  ami                    = var.private_ec2_ami_region_2
-  instance_type          = var.private_ec2_type
+  ami                    = data.aws_ami.amazon_linux_region_2.id
+  instance_type          = var.ec2_type
   availability_zone      = element(data.aws_availability_zones.region_2.names, count.index)
   subnet_id              = element(resource.aws_subnet.region_2_private_subnets.*.id, count.index)
   vpc_security_group_ids = [resource.aws_security_group.private_sg_region_2.id]
   provider               = aws.region_2
   tags = {
     Name = "EC2 in Private Subnet ${count.index} in ${var.region_2}"
+  }
+
+}
+# Create test EC2 instance in each public subnet in region 1
+resource "aws_instance" "public_ec2_region_1" {
+
+  count                  = length(var.vpc_region1_public_subnets)
+  ami                    = data.aws_ami.amazon_linux_region_1.id
+  instance_type          = var.ec2_type
+  availability_zone      = element(data.aws_availability_zones.region_1.names, count.index)
+  subnet_id              = element(module.vpc_region_1.public_subnets, count.index)
+  vpc_security_group_ids = [resource.aws_security_group.public_sg_region_1.id]
+  provider               = aws.region_1
+  tags = {
+    Name = "Public EC2 in ${var.region_1}"
+  }
+
+}
+# Create test EC2 instance in each public subnet in region 2
+resource "aws_instance" "public_ec2_region_2" {
+
+  count                  = length(var.vpc_region2_public_subnets)
+  ami                    = data.aws_ami.amazon_linux_region_2.id
+  instance_type          = var.ec2_type
+  availability_zone      = element(data.aws_availability_zones.region_2.names, count.index)
+  subnet_id              = element(module.vpc_region_2.public_subnets, count.index)
+  vpc_security_group_ids = [resource.aws_security_group.public_sg_region_2.id]
+  provider               = aws.region_2
+  tags = {
+    Name = "Public EC2 in ${var.region_2}"
   }
 
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,3 +47,9 @@ output "aws_eip_ids_region_2" {
   value       = resource.aws_eip.nat_gw_eip_region_2.*.allocation_id
 
 }
+output "module_vpc_output" {
+
+  description = "Output of VPC module for testing"
+  value       = data.aws_ami.amazon_linux_region_1.arn
+
+}

--- a/variables.tf
+++ b/variables.tf
@@ -8,7 +8,7 @@ variable "profile" {
   default     = "terraform_user"
 
 }
-variable "private_ec2_type" {
+variable "ec2_type" {
 
   type        = string
   description = "Set instance type for ec2 in private subnets"
@@ -46,13 +46,13 @@ variable "vpc_region1_private_subnets" {
   default     = ["10.0.3.0/24", "10.0.4.0/24"]
 
 }
-variable "private_ec2_ami_region_1" {
-
-  type        = string
-  description = "Set AMI for image for ec2 image deployed in private subnets in region 1"
-  default     = "ami-05fa00d4c63e32376"
-
-}
+#variable "ec2_ami_region_1" {
+#
+#  type        = string
+#  description = "Set AMI for image for ec2 image deployed in private subnets in region 1"
+#  default     = "ami-05fa00d4c63e32376"
+#
+#}
 
 #### REGION 2 VARIABLES ####
 
@@ -84,10 +84,10 @@ variable "vpc_region2_private_subnets" {
   default     = ["192.168.3.0/24", "192.168.4.0/24"]
 
 }
-variable "private_ec2_ami_region_2" {
-
-  type        = string
-  description = "Set AMI for image for ec2 image deployed in private subnets in region 2"
-  default     = "ami-0c2ab3b8efb09f272"
-
-}
+#variable "ec2_ami_region_2" {
+#
+#  type        = string
+#  description = "Set AMI for image for ec2 image deployed in private subnets in region 2"
+#  default     = "ami-0c2ab3b8efb09f272"
+#
+#}


### PR DESCRIPTION
Added code to create EC2 instances in public subnets and created data source to grab most up-to-date AMI value instead of hardcoded values.